### PR TITLE
fixed bug in chrf++code

### DIFF
--- a/evaluation/summ_eval/chrfpp_metric.py
+++ b/evaluation/summ_eval/chrfpp_metric.py
@@ -22,6 +22,8 @@ class ChrfppMetric(Metric):
         self.n_workers = n_workers
 
     def evaluate_example(self, summary, reference):
+        if not isinstance(reference, list):
+            reference = [reference]
         score = sacrebleu.sentence_chrf(summary, reference, order=self.ncorder, beta=self.beta)
         score_dict = {"chrf": score.score}
         return score_dict


### PR DESCRIPTION
added a datatype checker to avoid the program from crashing for single reference test cases, as the sentence_chrf() function  requires reference of type list