### PR TITLE
Fix dirname not found

### DIFF
--- a/evaluation/summ_eval/syntactic_metric.py
+++ b/evaluation/summ_eval/syntactic_metric.py
@@ -8,6 +8,8 @@ from stanza.server import CoreNLPClient
 from summ_eval.metric import Metric
 from summ_eval.syntactic_utils import get_stats
 
+dirname = os.path.dirname(__file__)
+
 if not os.path.exists(os.path.join(dirname, "stanford-corenlp-full-2018-10-05")):
     url = 'http://nlp.stanford.edu/software/stanford-corenlp-full-2018-10-05.zip'
     r = requests.get(url)


### PR DESCRIPTION
For syntactic metric, the dirname was not defined which throws an error when using.