### PR TITLE
Bugfixes

### DIFF
--- a/evaluation/setup.py
+++ b/evaluation/setup.py
@@ -42,6 +42,8 @@ setup(name='summ_eval',
           'scipy',
           'networkx',
           'blanc',
+          'scikit-learn',
+          'wmd',
       ],
       entry_points={
           'console_scripts': [

--- a/evaluation/summ_eval/data_stats_metric.py
+++ b/evaluation/summ_eval/data_stats_metric.py
@@ -2,15 +2,17 @@
 from collections import Counter
 from multiprocessing import Pool
 import gin
+import logging
 import spacy
 from summ_eval.data_stats_utils import Fragments
 from summ_eval.metric import Metric
 
+logger = logging.getLogger(__name__)
+
 try:
     _en = spacy.load('en_core_web_sm')
 except OSError:
-    print('Downloading the spacy en_core_web_sm model\n'
-        "(don't worry, this will only happen once)", file=stderr)
+    logger.info("Downloading the spacy en_core_web_sm model\n (don't worry, this will only happen once)")
     from spacy.cli import download
     download('en_core_web_sm')
     _en = spacy.load('en_core_web_sm')

--- a/evaluation/summ_eval/sentence_transformers/SentenceTransformer.py
+++ b/evaluation/summ_eval/sentence_transformers/SentenceTransformer.py
@@ -50,7 +50,7 @@ class SentenceTransformer(nn.Sequential):
 
 
                 if not os.listdir(model_path):
-                    if model_url[-1] is "/":
+                    if model_url[-1] == "/":
                         model_url = model_url[:-1]
                     logging.info("Downloading sentence transformer model from {} and saving it at {}".format(model_url, model_path))
                     try:

--- a/evaluation/summ_eval/sentence_transformers/losses/test_batch_hard_triplet_loss.py
+++ b/evaluation/summ_eval/sentence_transformers/losses/test_batch_hard_triplet_loss.py
@@ -1,6 +1,6 @@
 import numpy as np
 import torch
-from sentence_transformers.losses import BatchHardTripletLoss
+from summ_eval.sentence_transformers.losses import BatchHardTripletLoss
 
 # Test-suite from https://github.com/omoindrot/tensorflow-triplet-loss/blob/master/model/tests/test_triplet_loss.py
 # Skipped the `test_gradients_pairwise_distances()` test since it's trivial to see if your model loss turns NaN


### PR DESCRIPTION
Fix the errors that arise while running tests:
* missing imports
* incomplete import
* undeclared variable (I switched to the logging library instead of printing to `stderr` to solve this)