### PR TITLE
Replace 'stderr' with 'sys.stderr' to fix `NameError`

### DIFF
--- a/evaluation/summ_eval/calc_scores.py
+++ b/evaluation/summ_eval/calc_scores.py
@@ -217,7 +217,7 @@ def cli_main():
             nlp = spacy.load('en_core_web_md')
         except OSError:
             print('Downloading the spacy en_core_web_md model\n'
-                "(don't worry, this will only happen once)", file=stderr)
+                "(don't worry, this will only happen once)", file=sys.stderr)
             from spacy.cli import download
             download('en_core_web_md')
             nlp = spacy.load('en_core_web_md')

--- a/evaluation/summ_eval/sentence_movers_utils.py
+++ b/evaluation/summ_eval/sentence_movers_utils.py
@@ -19,7 +19,7 @@ try:
     nlp = spacy.load('en_core_web_sm')
 except OSError:
     print('Downloading the spacy en_core_web_sm model\n'
-        "(don't worry, this will only happen once)", file=stderr)
+        "(don't worry, this will only happen once)", file=sys.stderr)
     from spacy.cli import download
     download('en_core_web_sm')
     nlp = spacy.load('en_core_web_sm')


### PR DESCRIPTION
Certain code paths currently fail with `NameError: name 'stderr' is not defined`, since `stderr` is used without importing it or using the `sys` prefix. This PR fixes it.