### PR TITLE
Replace printing with logging

### DIFF
--- a/data_processing/pair_data.py
+++ b/data_processing/pair_data.py
@@ -7,6 +7,11 @@ import json
 import os
 from tqdm import tqdm
 
+from summ_eval import logger
+
+
+logger = logger.getChild(__name__)
+
 
 def parse_story_file(content):
     """
@@ -17,7 +22,7 @@ def parse_story_file(content):
     return content
 
 def annotation_pairing(args):
-    print("Processing file:", args.data_annotations)
+    logger.debug("Processing file: %s", args.data_annotations)
     with open(args.data_annotations) as fd:
         dataset = [json.loads(line) for line in fd]
 
@@ -46,7 +51,7 @@ def output_pairing(args):
         if not (".jsonl" in filename and "aligned" in filename and os.path.isfile(unpaired_path)):
             continue
 
-        print("Processing file:", unpaired_path)
+        logger.info("Processing file: %s", unpaired_path)
         with open(unpaired_path) as fd:
             dataset = [json.loads(line) for line in fd]
 

--- a/evaluation/summ_eval/__init__.py
+++ b/evaluation/summ_eval/__init__.py
@@ -1,0 +1,3 @@
+import logging
+
+logger = logging.getLogger(__name__)

--- a/evaluation/summ_eval/bert_score_metric.py
+++ b/evaluation/summ_eval/bert_score_metric.py
@@ -1,7 +1,11 @@
 import gin
 import bert_score
 
+from summ_eval import logger
 from summ_eval.metric import Metric
+
+
+logger = logger.getChild(__name__)
 
 
 @gin.configurable
@@ -46,7 +50,7 @@ class BertScoreMetric(Metric):
                                                 verbose=self.verbose, idf=self.idf, batch_size=self.batch_size,
                                                 nthreads=self.nthreads, lang=self.lang, return_hash=True,
                                                 rescale_with_baseline=self.rescale_with_baseline)
-        print(f"hash_code: {hash_code}")
+        logger.debug(f"hash_code: {hash_code}")
         score = {"bert_score_precision": all_preds[0].cpu().item(), "bert_score_recall": all_preds[1].cpu().item(), "bert_score_f1":
                 all_preds[2].cpu().item()}
         return score
@@ -57,7 +61,7 @@ class BertScoreMetric(Metric):
                                                 verbose=self.verbose, idf=self.idf, batch_size=self.batch_size,
                                                 nthreads=self.nthreads, lang=self.lang, return_hash=True,
                                                 rescale_with_baseline=self.rescale_with_baseline)
-        print(f"hash_code: {hash_code}")
+        logger.debug(f"hash_code: {hash_code}")
         if aggregate:
             avg_scores = [s.mean(dim=0) for s in all_preds]
             p_val = avg_scores[0].cpu().item()

--- a/evaluation/summ_eval/bleu_metric.py
+++ b/evaluation/summ_eval/bleu_metric.py
@@ -3,6 +3,8 @@ from multiprocessing import Pool
 import gin
 import sacrebleu
 from summ_eval.metric import Metric
+import warnings
+
 
 @gin.configurable
 class BleuMetric(Metric):
@@ -33,7 +35,7 @@ class BleuMetric(Metric):
         self.n_workers = n_workers
 
     def evaluate_example(self, summary, reference):
-        #print("BLEU is intended as a corpus-level metric. Be careful!")
+        warnings.warn("BLEU is intended as a corpus-level metric. Be careful!")
         if isinstance(reference, str):
             reference = [reference]
         score = sacrebleu.sentence_bleu(summary, reference, smooth_method=self.sent_smooth_method, \

--- a/evaluation/summ_eval/meteor_metric.py
+++ b/evaluation/summ_eval/meteor_metric.py
@@ -9,16 +9,18 @@ import logging
 import os
 import re
 import subprocess
-import sys
 import threading
 import psutil
 import requests
+
+from summ_eval import logger
 from summ_eval.metric import Metric
 
 dirname = os.path.dirname(__file__)
+logger = logger.getChild(__name__)
 
 if not os.path.exists(os.path.join(dirname, "meteor-1.5.jar")):
-    print("Downloading the meteor jar")
+    logger.info("Downloading the meteor jar")
     url = 'https://github.com/Maluuba/nlg-eval/blob/master/nlgeval/pycocoevalcap/meteor/meteor-1.5.jar?raw=true'
     r = requests.get(url)
     with open(os.path.join(dirname, "meteor-1.5.jar"), "wb") as outputf:
@@ -102,9 +104,9 @@ class MeteorMetric(Metric):
             try:
                 scores.append(float(dec(v.strip())))
             except:
-                sys.stderr.write("Error handling value: {}\n".format(v))
-                sys.stderr.write("Decoded value: {}\n".format(dec(v.strip())))
-                sys.stderr.write("eval_line: {}\n".format(eval_line))
+                logger.error("Error handling value: {}\n".format(v))
+                logger.debug("Decoded value: {}\n".format(dec(v.strip())))
+                logger.debug("eval_line: {}\n".format(eval_line))
                 raise
             score = float(dec(self.meteor_p.stdout.readline()).strip())
         score_dict = {"meteor" : score}
@@ -126,9 +128,9 @@ class MeteorMetric(Metric):
                 try:
                     scores.append(float(dec(v.strip())))
                 except:
-                    sys.stderr.write("Error handling value: {}\n".format(v))
-                    sys.stderr.write("Decoded value: {}\n".format(dec(v.strip())))
-                    sys.stderr.write("eval_line: {}\n".format(eval_line))
+                    logger.error("Error handling value: {}\n".format(v))
+                    logger.debug("Decoded value: {}\n".format(dec(v.strip())))
+                    logger.debug("eval_line: {}\n".format(eval_line))
             score = float(dec(self.meteor_p.stdout.readline()).strip())
         if aggregate:
             score_dict = {"meteor" : score}

--- a/evaluation/summ_eval/rouge_metric.py
+++ b/evaluation/summ_eval/rouge_metric.py
@@ -3,15 +3,16 @@ import os
 from pathlib import Path
 import tempfile
 import shutil
-import logging
 import gin
+import logging
+import subprocess
+
+from summ_eval import logger
 from summ_eval.metric import Metric
 from summ_eval.test_util import rouge_empty
-import subprocess
-import logging
 
 
-logger = logging.getLogger()
+logger = logger.getChild(__name__)
 
 ROUGE_HOME = os.environ['ROUGE_HOME'] or Path(__file__).parent / "ROUGE-1.5.5"
 if "ROUGE_HOME" not in os.environ:
@@ -55,7 +56,7 @@ class RougeMetric(Metric):
         try:
             self.r = Rouge155(rouge_dir=rouge_dir, rouge_args=rouge_args, log_level=log_level)
         except:
-            print(f'Please run this command: \n pip install -U  git+https://github.com/bheinzerling/pyrouge.git')
+            logger.error(f'Please run this command: \n pip install -U  git+https://github.com/bheinzerling/pyrouge.git')
             exit()
         self.rouge_args = rouge_args
 

--- a/evaluation/summ_eval/rouge_we_metric.py
+++ b/evaluation/summ_eval/rouge_we_metric.py
@@ -5,15 +5,20 @@ from multiprocessing import Pool
 from collections import Counter
 import gin
 import bz2
+
+from summ_eval import logger
 from summ_eval.s3_utils import rouge_n_we, load_embeddings
 from summ_eval.metric import Metric
 
+
 dirname = os.path.dirname(__file__)
+logger = logger.getChild(__name__)
+
 
 if not os.path.exists(os.path.join(dirname, "embeddings")):
     os.mkdir(os.path.join(dirname, "embeddings"))
 if not os.path.exists(os.path.join(dirname, "embeddings/deps.words")):
-    print("Downloading the embeddings; this may take a while")
+    logger.info("Downloading the embeddings; this may take a while")
     url = "http://u.cs.biu.ac.il/~yogo/data/syntemb/deps.words.bz2"
     r = requests.get(url)
     d = bz2.decompress(r.content)

--- a/evaluation/summ_eval/s3_metric.py
+++ b/evaluation/summ_eval/s3_metric.py
@@ -5,15 +5,20 @@ from collections import Counter
 from multiprocessing import Pool
 import gin
 import bz2
+
+from summ_eval import logger
 from summ_eval.metric import Metric
 from summ_eval.s3_utils import S3, load_embeddings
 
+
 dirname = os.path.dirname(__file__)
+logger = logger.getChild(__name__)
+
 
 if not os.path.exists(os.path.join(dirname, "embeddings")):
     os.mkdir(os.path.join(dirname, "embeddings"))
 if not os.path.exists(os.path.join(dirname, "embeddings/deps.words")):
-    print("Downloading the embeddings; this may take a while")
+    logger.info("Downloading the embeddings; this may take a while")
     url = "http://u.cs.biu.ac.il/~yogo/data/syntemb/deps.words.bz2"
     r = requests.get(url)
     d = bz2.decompress(r.content)

--- a/evaluation/summ_eval/sentence_movers_utils.py
+++ b/evaluation/summ_eval/sentence_movers_utils.py
@@ -11,15 +11,17 @@ from wmd import WMD
 from nltk.corpus import stopwords
 #from allennlp.commands.elmo import ElmoEmbedder
 
+from summ_eval import logger
+
+logger = logger.getChild(__name__)
 stop_words = set(stopwords.words('english'))
 
-print("loading spacy")
-
 try:
+    logger.info("Loading spacy")
     nlp = spacy.load('en_core_web_sm')
 except OSError:
-    print('Downloading the spacy en_core_web_sm model\n'
-        "(don't worry, this will only happen once)", file=stderr)
+    logger.info('Downloading the spacy en_core_web_sm model\n'
+        "(don't worry, this will only happen once)")
     from spacy.cli import download
     download('en_core_web_sm')
     nlp = spacy.load('en_core_web_sm')
@@ -228,7 +230,7 @@ def calc_smd(input_f, output_f="", WORD_REP='elmo', METRIC='sms'):
     inF = open(input_f, 'r')
     inLines = inF.readlines()
     inF.close()
-    #print("Found", len(inLines), "documents")
+    logger.debug("Found", len(inLines), "documents")
     token_doc_list, text_doc_list = tokenize_texts(inLines, WORD_REP, tokenize=True)
     count = 0
     results_list = []
@@ -245,11 +247,11 @@ def calc_smd(input_f, output_f="", WORD_REP='elmo', METRIC='sms'):
         try:
             dist = calc.nearest_neighbors(str(0), k=1, early_stop=1)[0][1]  # how far is hyp from ref?
         except Exception as e:
-            print(e)
+            logger.error(e)
         sim = math.exp(-dist)  # switch to similarity
         results_list.append(sim)
         if doc_id == int((len(token_doc_list) / 10.) * count):
-            print(str(count * 10) + "% done with calculations")
+            logger.info(str(count * 10) + "% done with calculations")
             count += 1
     if output_f != "":
         print_score(inLines, output_f, results_list)

--- a/evaluation/summ_eval/sentence_transformers/SentenceTransformer.py
+++ b/evaluation/summ_eval/sentence_transformers/SentenceTransformer.py
@@ -16,10 +16,14 @@ from torch.optim import Optimizer
 from torch.utils.data import DataLoader
 from tqdm import tqdm, trange
 
-from . import __DOWNLOAD_SERVER__
+from . import __DOWNLOAD_SERVER__, logger
 from .evaluation import SentenceEvaluator
 from .util import import_from_string, batch_to_device, http_get
 from . import __version__
+
+
+logger = logger.getChild(__name__)
+
 
 class SentenceTransformer(nn.Sequential):
     def __init__(self, model_name_or_path: str = None, modules: Iterable[nn.Module] = None, device: str = None):
@@ -97,7 +101,7 @@ class SentenceTransformer(nn.Sequential):
            a list with ndarrays of the embeddings for each sentence
         """
         if show_progress_bar is None:
-            show_progress_bar = (logging.getLogger().getEffectiveLevel()==logging.INFO or logging.getLogger().getEffectiveLevel()==logging.DEBUG)
+            show_progress_bar = (logger.getEffectiveLevel()==logging.INFO or logger.getEffectiveLevel()==logging.DEBUG)
 
         all_embeddings = []
         all_token_embeddings = []
@@ -159,7 +163,7 @@ class SentenceTransformer(nn.Sequential):
 
     def list_functions(self):
         functions_list = [o for o in getmembers(self._first_module()) if isfunction(o[1])]
-        print(functions_list)
+        logger.debug(functions_list)
 
     def get_sentence_features(self, *features):
         return self._first_module().get_sentence_features(*features)

--- a/evaluation/summ_eval/sentence_transformers/__init__.py
+++ b/evaluation/summ_eval/sentence_transformers/__init__.py
@@ -1,7 +1,13 @@
 __version__ = "0.2.3"
 __DOWNLOAD_SERVER__ = 'https://public.ukp.informatik.tu-darmstadt.de/reimers/sentence-transformers/v0.2/'
+
+from summ_eval import logger
+
 from .datasets import SentencesDataset, SentenceLabelDataset
 from .data_samplers import LabelSampler
 from .LoggingHandler import LoggingHandler
 from .SentenceTransformer import SentenceTransformer
+
+
+logger = logger.getChild(__name__)
 

--- a/evaluation/summ_eval/sentence_transformers/datasets.py
+++ b/evaluation/summ_eval/sentence_transformers/datasets.py
@@ -12,6 +12,10 @@ import numpy as np
 from tqdm import tqdm
 from . import SentenceTransformer
 from .readers.InputExample import InputExample
+from . import logger
+
+
+logger = logger.getChild(__name__)
 
 
 class SentencesDataset(Dataset):

--- a/evaluation/summ_eval/sentence_transformers/evaluation/EmbeddingSimilarityEvaluator.py
+++ b/evaluation/summ_eval/sentence_transformers/evaluation/EmbeddingSimilarityEvaluator.py
@@ -11,6 +11,11 @@ from sklearn.metrics.pairwise import paired_cosine_distances, paired_euclidean_d
 from scipy.stats import pearsonr, spearmanr
 import numpy as np
 
+from summ_eval import logger
+
+
+logger = logger.getChild(__name__)
+
 class EmbeddingSimilarityEvaluator(SentenceEvaluator):
     """
     Evaluate a model based on the similarity of the embeddings by calculating the Spearman and Pearson rank correlation
@@ -40,7 +45,7 @@ class EmbeddingSimilarityEvaluator(SentenceEvaluator):
             name = "_"+name
 
         if show_progress_bar is None:
-            show_progress_bar = (logging.getLogger().getEffectiveLevel() == logging.INFO or logging.getLogger().getEffectiveLevel() == logging.DEBUG)
+            show_progress_bar = (logger.getEffectiveLevel() == logging.INFO or logger.getEffectiveLevel() == logging.DEBUG)
         self.show_progress_bar = show_progress_bar
 
         self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
@@ -81,8 +86,8 @@ class EmbeddingSimilarityEvaluator(SentenceEvaluator):
         try:
             cosine_scores = 1 - (paired_cosine_distances(embeddings1, embeddings2))
         except Exception as e:
-            print(embeddings1)
-            print(embeddings2)
+            logger.debug(embeddings1)
+            logger.debug(embeddings2)
             raise(e)
 
         manhattan_distances = -paired_manhattan_distances(embeddings1, embeddings2)

--- a/evaluation/summ_eval/sentence_transformers/losses/test_batch_hard_triplet_loss.py
+++ b/evaluation/summ_eval/sentence_transformers/losses/test_batch_hard_triplet_loss.py
@@ -214,4 +214,3 @@ if __name__ == '__main__':
     test_anchor_positive_triplet_mask()
     test_anchor_negative_triplet_mask()
     test_batch_hard_triplet_loss()
-    print("--TESTS done ---")

--- a/evaluation/summ_eval/sentence_transformers/util.py
+++ b/evaluation/summ_eval/sentence_transformers/util.py
@@ -5,6 +5,10 @@ from tqdm import tqdm
 import sys
 import importlib
 
+from summ_eval.sentence_transformers import logger
+
+
+logger = logger.getChild(__name__)
 
 def batch_to_device(batch, target_device: device):
     """
@@ -28,7 +32,7 @@ def http_get(url, path):
     file_binary = open(path, "wb")
     req = requests.get(url, stream=True)
     if req.status_code != 200:
-        print("Exception when trying to download {}. Response {}".format(url, req.status_code), file=sys.stderr)
+        logger.error("Exception when trying to download %s. Response %s", url, req.status_code)
         req.raise_for_status()
 
     content_length = req.headers.get('Content-Length')

--- a/evaluation/summ_eval/summa_qa_metric.py
+++ b/evaluation/summ_eval/summa_qa_metric.py
@@ -1,15 +1,19 @@
 # pylint: disable=W0221,C0103
-import sys
 import spacy
 import gin
+
+from summ_eval import logger
 from summ_eval.summa_qa_utils import QA_Metric, QG_masked, evaluate_corpus
 from summ_eval.metric import Metric
+
+
+logger = logger.getChild(__name__)
 
 try:
     nlp = spacy.load('en_core_web_sm')
 except OSError:
-    print('Downloading the spacy en_core_web_sm model\n'
-        "(don't worry, this will only happen once)", file=sys.stderr)
+    logger.info('Downloading the spacy en_core_web_sm model\n'
+        "(don't worry, this will only happen once)")
     from spacy.cli import download
     download('en_core_web_sm')
     nlp = spacy.load('en_core_web_sm')

--- a/evaluation/summ_eval/supert_metric.py
+++ b/evaluation/summ_eval/supert_metric.py
@@ -6,9 +6,13 @@ from collections import Counter
 from nltk.tokenize import sent_tokenize
 import gin
 
+from summ_eval import logger
 from summ_eval.sentence_transformers import SentenceTransformer
 from summ_eval.metric import Metric
 from summ_eval.supert_utils import parse_documents, get_all_token_vecs, build_pseudo_ref, get_sbert_score, get_token_vecs
+
+
+logger = logger.getChild(__name__)
 
 try:
     PYTHONPATH = os.environ['PYTHONPATH']
@@ -18,7 +22,11 @@ except:
 dirname = os.path.dirname(__file__)
 
 if dirname not in PYTHONPATH:
-    print(f'Please run the following command and add it to your startup script: \n export PYTHONPATH=$PYTHONPATH:{dirname}')
+    logger.error(
+        "Please run the following command and add it to your startup script: "
+        "\n export PYTHONPATH=$PYTHONPATH:%s",
+        dirname,
+    )
     exit()
 
 @gin.configurable

--- a/evaluation/summ_eval/syntactic_metric.py
+++ b/evaluation/summ_eval/syntactic_metric.py
@@ -5,17 +5,21 @@ import os
 import requests
 import zipfile, io
 from stanza.server import CoreNLPClient
+
+from summ_eval import logger
 from summ_eval.metric import Metric
 from summ_eval.syntactic_utils import get_stats
 
+
 dirname = os.path.dirname(__file__)
+logger = logger.getChild(__name__)
 
 if not os.path.exists(os.path.join(dirname, "stanford-corenlp-full-2018-10-05")):
     url = 'http://nlp.stanford.edu/software/stanford-corenlp-full-2018-10-05.zip'
     r = requests.get(url)
     z = zipfile.ZipFile(io.BytesIO(r.content))
     z.extractall(os.path.join(dirname, "./"))
-    print(f'Please run the following command and add it to your startup script: \n export CORENLP_HOME={os.path.join(dirname, "./stanford-corenlp-full-2018-10-05/")}')
+    logger.error(f'Please run the following command and add it to your startup script: \n export CORENLP_HOME={os.path.join(dirname, "./stanford-corenlp-full-2018-10-05/")}')
 
 @gin.configurable
 class SyntacticMetric(Metric):
@@ -47,7 +51,7 @@ class SyntacticMetric(Metric):
             else:
                 corpus_score_dict = []
             for count, summ in enumerate(summaries):
-                print(count)
+                logger.debug(count)
                 stats = get_stats(client, summ)
                 if aggregate:
                     corpus_score_dict.update(stats)


### PR DESCRIPTION
Using logging, instead of printing, allows the output to be systematically handled: filtering on level and routing to different/multiple locations. This PR should reduce the noise of running SummEval, although this could go further by handling output of SummEval's dependencies.